### PR TITLE
fix: bump pinned base image digest (debian:trixie-slim security rebuild)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # regardless, since users receive nothing except through a release.
 # tests/base-image-freshness.sh runs weekly and reports when this pin has fallen
 # behind, so "deliberate" does not decay into "forgotten".
-FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
- `tests/base-image-freshness.sh` (scheduled, weekly) has been red since 2026-08-31: the digest-pinned `debian:trixie-slim` base image had fallen behind Debian's security rebuild.
- Bumped `Dockerfile`'s `FROM` pin from `sha256:3a39a059…` to the current `sha256:d7e12182…`.

## Verification
- Bundled `borgbackup` stays at `1.4.0-5` in both old and new digest — no Borg version move, so no release-notes/version-note update needed for that.
- Built the image against the new digest and ran `tests/wrapper-gating.sh` with `WRAPPER=/borg-wrapper.sh` against the wrapper shipped in that image: **40/40 passed**.

## Test plan
- [x] `docker build` succeeds against new digest
- [x] `tests/wrapper-gating.sh` passes 40/40 against the in-image wrapper
- [ ] CI `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE