### PR TITLE
fix: shadow podman by name, not by directory, in the missing-podman test

### DIFF
--- a/tests/host-scripts.sh
+++ b/tests/host-scripts.sh
@@ -910,11 +910,25 @@ OUT="$(printf 'y\n' | PATH="$STUB:$DF_BIN:$PATH" "$WORK/sh" "$T/scripts/00-ssh-c
 assert "10.17 the same run under bash-as-sh behaves identically" $?
 
 # podman missing is checked before anything is created, not halfway through.
+#
+# The script still needs the ordinary coreutils that live in /usr/bin, so
+# this can't just point PATH at NOPODMAN and stop. It also can't append
+# /usr/bin itself: some runner images now ship a real podman there, which
+# would make "missing" stop being missing. So SAFEBIN mirrors /usr/bin with
+# symlinks, minus podman, and PATH never touches the real /usr/bin at all —
+# /bin is commonly a symlink to /usr/bin (merged-usr), so excluding the
+# directory instead of the one file would have thrown out every coreutil too.
 setup_create
 NOPODMAN="$WORK/nopodman"; mkdir -p "$NOPODMAN"
 cp "$STUB/sudo" "$STUB/xfs_quota" "$STUB/lsattr" "$NOPODMAN/"
+SAFEBIN="$WORK/safebin"; mkdir -p "$SAFEBIN"
+for f in /usr/bin/*; do
+    b="${f##*/}"
+    [ "$b" = "podman" ] && continue
+    ln -s "$f" "$SAFEBIN/$b" 2>/dev/null
+done
 df_stub "$T/repo:$((4000 * GIB)):0"
-OUT="$(printf 'y\n' | PATH="$NOPODMAN:$DF_BIN:/usr/bin:/bin" "$T/scripts/00-ssh-create-user.sh" user1 50G 2>&1)"; RC=$?
+OUT="$(printf 'y\n' | PATH="$NOPODMAN:$DF_BIN:$SAFEBIN" "$T/scripts/00-ssh-create-user.sh" user1 50G 2>&1)"; RC=$?
 [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q 'podman not found'
 assert "10.18 a missing podman is reported before anything is created" $?
 


### PR DESCRIPTION
## Summary
- Discovered while checking CI on #36: `tests/host-scripts.sh` test 10.18 ("a missing podman is reported before anything is created") started failing on `main` on 2026-09-07, unrelated to that PR's base-image digest bump — reproduced identically on `main`@`43f9dcc` itself.
- Root cause: the test simulated "no podman" via `PATH="$NOPODMAN:$DF_BIN:/usr/bin:/bin"`, assuming `/usr/bin:/bin` never carries a real `podman`. A GitHub-hosted runner image update (`ubuntu-24.04`, image version `20260831.293.1`) now ships one there, so the script's `command -v podman` check stopped failing, the script proceeded into a real `quota_verify()` call, and hit the real (expected) "quota is NOT enforced" abort on the runner's non-XFS `/tmp` instead of the `podman not found` message the test greps for.
- Fix: instead of appending the real `/usr/bin:/bin`, mirror `/usr/bin` into a fresh `SAFEBIN` directory of symlinks with the `podman` entry skipped, and point `PATH` at that. Excluding `/usr/bin` or `/bin` wholesale isn't viable — on merged-usr systems `/bin` is a symlink to `/usr/bin`, so dropping whichever directory has `podman` would drop every coreutil the script needs too.

## Verification
- `bash tests/host-scripts.sh`: 123/123 passed locally.
- No real `podman` on this dev machine, so also simulated a directory with a real `podman` binary present and confirmed `SAFEBIN` excludes it from `command -v podman` while ordinary commands (e.g. `mkdir`) stay resolvable.
- `shellcheck --severity=warning` (matching CI's invocation): clean on the changed lines.

## Test plan
- [x] `bash tests/host-scripts.sh` passes locally
- [x] Simulated real-podman-in-/usr/bin scenario confirms the shadow holds
- [ ] CI `Tests` workflow green on this PR (this is what it's meant to fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE