### PR TITLE
fix: pin borgbackup and openssh-server to exact apt versions (F-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,20 @@ jobs:
       - name: Compare the pinned digest against the upstream tag
         run: tests/base-image-freshness.sh
 
+  package-pin-freshness:
+    name: package pins are current
+    runs-on: ubuntu-latest
+    # Schedule and manual dispatch only, for the same reason as
+    # base-image-freshness above: a newer package in the pool is a
+    # maintenance signal, not a defect in the commit under test.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compare the pinned package versions against the base image's pool
+        run: tests/package-pin-freshness.sh
+
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,22 @@ FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc401
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install base packages
+# Pinned by exact version, for the same reason the base image is pinned by
+# digest: apt always installs whatever is currently in trixie's package pool,
+# so two builds of the same commit — and same base image digest — can still
+# carry a different borgbackup or openssh-server. That gap matters more for
+# borgbackup than for most packages: borg-wrapper.sh's encryption check reads
+# the repository manifest's TYPE byte directly (see its own top-of-file
+# comment), so which borg version actually ships is not a detail.
+#
+# The cost is symmetric with the base image, too: apt refuses to install a
+# version that has aged out of the pool, so a stale pin here does not decay
+# silently — it fails the very next build. tests/package-pin-freshness.sh
+# also polls weekly, the same way tests/base-image-freshness.sh does for the
+# base image, so the pin can be bumped deliberately before that happens.
 RUN apt-get update && apt-get install -y \
-    borgbackup \
-    openssh-server \
+    borgbackup=1.4.0-5 \
+    openssh-server=1:10.0p1-7+deb13u4 \
     && rm -rf /var/lib/apt/lists/*
 
 # Prepare SSH

--- a/tests/package-pin-freshness.sh
+++ b/tests/package-pin-freshness.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# tests/package-pin-freshness.sh
+# -------------------------------
+# Reports when an exact-version apt pin in the Dockerfile has fallen behind
+# the version Debian now offers for it in the pinned base image's own
+# package pool.
+#
+# Pinning packages by exact version buys the same thing digest-pinning the
+# base image buys: two builds of the same commit install the same bits. The
+# trade is symmetric too — apt refuses to install a version that has aged
+# out of the pool, so a stale pin does not decay silently; it fails the very
+# next build (tests/wrapper-gating.sh's "wrapper suite inside the built
+# image" job builds the image on every push and pull request, so that
+# failure surfaces fast). This check exists to give operators the same
+# advance, deliberate notice tests/base-image-freshness.sh gives for the base
+# layer, instead of finding out only when an unrelated push's build goes red.
+#
+# A newer package in the pool is a maintenance signal, not a defect in
+# whatever commit is being tested, which is why — like base-image-freshness
+# — this does not run on pull requests.
+#
+# Requires: bash, docker.
+# Usage:    tests/package-pin-freshness.sh
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+echo "# apt version pins vs. the pinned base image's package pool"
+echo
+
+BASE_REF="$(grep -oE '^FROM +debian:trixie-slim@sha256:[0-9a-f]+' Dockerfile 2>/dev/null \
+    | awk '{print $2}')"
+
+if [ -z "$BASE_REF" ]; then
+    echo "FAIL the Dockerfile does not pin the base image by digest — see"
+    echo "     tests/base-image-freshness.sh; nothing to check pinned packages against."
+    exit 1
+fi
+
+command -v docker >/dev/null || { echo "FAIL docker is required" >&2; exit 1; }
+
+# One package per "name=version" token on the apt-get install line.
+mapfile -t PINS < <(
+    sed -n '/apt-get install -y/,/rm -rf \/var\/lib\/apt\/lists/p' Dockerfile \
+        | grep -oE '^[[:space:]]*[A-Za-z0-9.+-]+=[A-Za-z0-9.:+~-]+[[:space:]]*\\?$' \
+        | sed -E 's/^[[:space:]]*//; s/[[:space:]]*\\?$//'
+)
+
+if [ "${#PINS[@]}" -eq 0 ]; then
+    echo "FAIL no 'package=version' pins found on the apt-get install line in the Dockerfile."
+    exit 1
+fi
+
+NAMES=()
+for p in "${PINS[@]}"; do NAMES+=("${p%%=*}"); done
+
+CANDIDATES="$(docker run --rm "$BASE_REF" bash -c '
+    apt-get update -qq >/dev/null 2>&1
+    for p in "$@"; do
+        apt-cache policy "$p" | awk -v pkg="$p" "/Candidate:/ {print pkg\"=\"\$2}"
+    done
+' _ "${NAMES[@]}" 2>/dev/null)"
+
+if [ -z "$CANDIDATES" ]; then
+    echo "FAIL could not read candidate package versions from the pinned base image."
+    echo "     This is a build/registry-reachability failure, not a stale pin."
+    exit 1
+fi
+
+fail=0
+for pin in "${PINS[@]}"; do
+    name="${pin%%=*}"
+    pinned_ver="${pin#*=}"
+    candidate_ver="$(printf '%s\n' "$CANDIDATES" | grep "^${name}=" | head -1 | cut -d= -f2-)"
+
+    if [ -z "$candidate_ver" ]; then
+        echo "FAIL could not read the candidate version for '$name'."
+        fail=1
+        continue
+    fi
+
+    if [ "$pinned_ver" = "$candidate_ver" ]; then
+        printf 'ok   %-15s pinned %s matches the current candidate\n' "$name" "$pinned_ver"
+    else
+        printf 'STALE %-14s pinned %s, pool now offers %s\n' "$name" "$pinned_ver" "$candidate_ver"
+        fail=1
+    fi
+done
+echo
+
+if [ "$fail" -eq 0 ]; then
+    echo "ok   all pinned package versions are current"
+    exit 0
+fi
+
+cat <<EOF
+Debian's package pool has moved past one or more pins above. To act on it:
+
+  1. Update the affected "name=version" token(s) on the apt-get install line
+     in the Dockerfile.
+  2. If borgbackup moved, run tests/wrapper-gating.sh with
+     WRAPPER=/borg-wrapper.sh against a rebuilt image — it checks the wrapper
+     against the borg version the image actually carries.
+  3. Cut a release, since nothing reaches an operator otherwise.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

Addresses finding F-02 from an external repo assessment ("Docker-Build ist trotz Digest-Pinning nicht reproduzierbar", MEDIUM): digest-pinning the base image makes the OS layer reproducible, but `apt-get install borgbackup openssh-server` still pulled whatever trixie's package pool held at build time. Two builds of the same commit, from the same base digest, could still ship a different `borgbackup` or `openssh-server`.

That gap matters most for `borgbackup`: `borg-wrapper.sh`'s encryption check reads the repository manifest's TYPE byte directly (see its own top-of-file comment on version coupling), so which borg version actually ships is not incidental — the digest-bump PR (#36) verified the version at one point in time, but nothing was pinning it going forward.

## Changes

- `Dockerfile`: pin `borgbackup=1.4.0-5` and `openssh-server=1:10.0p1-7+deb13u4` — both the current candidates in the pinned base image's pool.
- New `tests/package-pin-freshness.sh`, mirroring `tests/base-image-freshness.sh`: builds against the pinned base digest and compares pinned vs. currently-offered candidate versions, reporting `STALE` per package if they've drifted.
- Wired into `test.yml` as a new `package-pin-freshness` job on the same `schedule`/`workflow_dispatch`-only trigger as `base-image-freshness`, so drift is a proactive weekly signal rather than something discovered only when an unrelated push's build goes red.

## Why this doesn't need a "reproducibility test" beyond the build itself

apt refuses to install a version that has aged out of the pool — verified locally with a deliberately wrong version (`borgbackup=1.4.0-999`): the build fails immediately with `E: Version '1.4.0-999' for 'borgbackup' was not found`. So a stale pin doesn't decay silently the way an un-pinned install would; it fails the very next build, the same way a bad digest pin would fail to resolve. The `wrapper suite inside the built image` job already runs `docker build` on every push/PR, so that failure surfaces fast on its own — `package-pin-freshness.sh` exists to give advance, deliberate notice instead.

## Verification
- Local `docker build` with the pinned versions: succeeds.
- Deliberately stale pin (`borgbackup=1.3.0-1`) reproduces both the real build failure and `package-pin-freshness.sh`'s `STALE` report.
- `tests/wrapper-gating.sh` against the pinned image: 40/40.
- `tests/host-scripts.sh` locally: 123/123.
- `shellcheck --severity=warning` (matching CI): clean on `Dockerfile`-adjacent changes and both freshness scripts.

## Test plan
- [x] `docker build` succeeds with the pinned versions
- [x] A deliberately stale pin fails the build and is reported `STALE` by the new script
- [x] `wrapper-gating.sh` and `host-scripts.sh` pass against the pinned image
- [ ] CI `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE