### PR TITLE
fix: pin GitHub Actions to commit SHAs, add Dependabot (F-03)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Workflow actions are pinned by commit SHA (tests/... has no equivalent
+  # freshness check for them, unlike the Docker base image and apt package
+  # pins — this is the off-the-shelf mechanism for the same problem).
+  # Dependabot opens a PR bumping the SHA when an action releases; normal CI
+  # runs against it before merge.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       # Derive tags, labels and OCI annotations from the pushed git tag.
       # - "type=semver,pattern={{version}}" -> version tag WITHOUT the leading
@@ -41,7 +41,7 @@ jobs:
       # reads the description for multi-arch images.
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
@@ -81,7 +81,7 @@ jobs:
         # registry (e.g. Kyverno/Sigstore policy-controller admission
         # checks, or `gh attestation verify --bundle-from-oci`) — not the
         # case here.
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-name: ghcr.io/raykhoefemann/hardened-borg-server
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # The suite drives the real wrapper against real Borg repositories, so
       # borgbackup is needed both as the `borg` CLI (to build fixtures) and as
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # The job above runs the wrapper against the runner's borg. The image
       # ships its own, and the two drifted apart unnoticed once "stable" moved
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # build_authorized_keys.sh writes to absolute paths (/config, /log,
       # /repo, /home/borg/.ssh); bubblewrap gives each case a tmpfs root with
@@ -94,7 +94,7 @@ jobs:
     # next manual VM verification.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: snapshots/ scripts
         run: tests/snapshot-scripts.sh
@@ -111,7 +111,7 @@ jobs:
     # classification -- is checked on every push.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: scripts/ repository-check tooling
         run: tests/check-repos-scripts.sh
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: VERSION, git tag, image tag and SOURCE_URL
         run: tests/doc-image-tags.sh consistency
@@ -139,7 +139,7 @@ jobs:
     if: github.event_name != 'push'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Check documented tags against GHCR
         run: tests/doc-image-tags.sh registry
@@ -155,7 +155,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Compare the pinned digest against the upstream tag
         run: tests/base-image-freshness.sh
@@ -169,7 +169,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Compare the pinned package versions against the base image's pool
         run: tests/package-pin-freshness.sh
@@ -185,7 +185,7 @@ jobs:
     # A linter that finds a platform-specific bug on day one is not advisory.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install shellcheck
         run: |


### PR DESCRIPTION
## Summary

Addresses finding F-03 from an external repo assessment ("GitHub Actions sind nicht auf Commit-SHAs gepinnt", MEDIUM): every `uses:` line in `test.yml` and `docker.yml` referenced a mutable major-version tag (`@v4`, `@v3`, `@v5`, `@v6`, `@v1`) rather than a fixed commit. The action's publisher can repoint a major tag to a different commit at any time, so CI trusted whatever currently sat behind the tag — a compromised or force-pushed tag could inject arbitrary code into the build/release pipeline (secrets access, GHCR push, the attestation step) with no corresponding change in this repository to review.

## Changes

Pinned every action to the exact commit its tag currently resolves to, with the version as a trailing comment (the standard, Dependabot-compatible format):

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@11d5960a…` (v4.4.0) |
| `docker/login-action` | `@v3` | `@c94ce9fb…` (v3.7.0) |
| `docker/setup-buildx-action` | `@v3` | `@8d2750c6…` (v3.12.0) |
| `docker/metadata-action` | `@v5` | `@c299e40c…` (v5.10.0) |
| `docker/build-push-action` | `@v6` | `@10e90e36…` (v6.19.2) |
| `actions/attest-build-provenance` | `@v1` | `@ef244123…` (v1.4.4) |

Added `.github/dependabot.yml` (`github-actions` ecosystem, weekly) so pins keep getting bumped — a PR with the new SHA, run through normal CI — instead of silently going stale. Unlike the Docker base image ([`#36`](../pull/36)) and apt package pins ([`#38`](../pull/38)), GitHub Actions already has this off-the-shelf via Dependabot, so no custom freshness script was needed here.

No functional change: every pin resolves to the exact commit the previous tag reference was already using.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"`: both workflow files and the new `dependabot.yml` parse.
- Each SHA verified via `gh api repos/<action>/git/refs/tags/<tag>` (dereferencing the one annotated tag, `attest-build-provenance`) against its resolved commit and matching semver tag.
- CI itself is the functional test: this PR's own workflow runs use the pinned SHAs.

## Test plan
- [x] YAML validates
- [x] SHAs independently verified against the GitHub API
- [ ] CI `Tests` workflow green on this PR (proves the pinned `actions/checkout` SHA works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE