### PR TITLE
fix: refuse to clobber a foreign timer/service unit on install (F-05)

### DIFF
--- a/scripts/21-check-timer-install.sh
+++ b/scripts/21-check-timer-install.sh
@@ -66,9 +66,46 @@ fi
 echo "[install] Rendering $RENDERED_SERVICE from template"
 sed "s|@@SCRIPT@@|${SCRIPT}|" "$SERVICE_TEMPLATE" > "$RENDERED_SERVICE"
 
-echo "[install] Installing systemd units as symlinks..."
 mkdir -p "$SERVICE_DIR"
 
+# Refuse to clobber another installation's timer/service units.
+#
+# Both are namespaced by CHECK_TIMER_NAME (scripts/config.sh), but two
+# checkouts that forgot to give the second a distinct name would both
+# resolve to the same $SERVICE_DIR/$TIMER_NAME and $SERVICE_DIR/$SERVICE_NAME
+# -- a plain install would silently replace the first checkout's units, and
+# because ExecStart embeds that checkout's own REPO_ROOT, the daily sweep
+# would end up running the wrong scripts under the second checkout's name.
+# Fail loudly instead, the same check 50-service-install.sh already applies
+# to the Quadlet: if the symlink is already here and does NOT point at this
+# checkout's own file, it belongs to another installation.
+check_not_foreign() {
+    TARGET="$1"; SOURCE="$2"
+    if [ -L "$TARGET" ]; then
+        EXISTING_TARGET="$(readlink -f "$TARGET" 2>/dev/null || true)"
+        SOURCE_REAL="$(readlink -f "$SOURCE" 2>/dev/null || echo "$SOURCE")"
+        if [ "$EXISTING_TARGET" != "$SOURCE_REAL" ]; then
+            echo "ERROR: '$TARGET' already exists and points at"
+            echo "       '${EXISTING_TARGET:-<unresolvable>}', not this checkout's"
+            echo "       '$SOURCE_REAL'."
+            echo "       CHECK_TIMER_NAME='${CHECK_TIMER_NAME}' is already in use by"
+            echo "       another installation of this project on this host. Give this"
+            echo "       one a distinct CHECK_TIMER_NAME in config.sh, or run"
+            echo "       ./scripts/22-check-timer-uninstall.sh from the other checkout"
+            echo "       first."
+            exit 1
+        fi
+    elif [ -e "$TARGET" ]; then
+        echo "ERROR: '$TARGET' exists but is not a symlink this script wrote."
+        echo "       Something placed it by hand. Move it aside and re-run."
+        exit 1
+    fi
+}
+
+check_not_foreign "$SERVICE_DIR/$TIMER_NAME" "$TIMER_UNIT"
+check_not_foreign "$SERVICE_DIR/$SERVICE_NAME" "$RENDERED_SERVICE"
+
+echo "[install] Installing systemd units as symlinks..."
 for TARGET in "$SERVICE_DIR/$TIMER_NAME" "$SERVICE_DIR/$SERVICE_NAME"; do
     if [ -e "$TARGET" ]; then
         echo "[install] Removing old file $TARGET"

--- a/snapshots/71-timer-install.sh
+++ b/snapshots/71-timer-install.sh
@@ -71,9 +71,46 @@ fi
 echo "[install] Rendering $RENDERED_SERVICE from template"
 sed "s|@@SCRIPT@@|${SCRIPT}|" "$SERVICE_TEMPLATE" > "$RENDERED_SERVICE"
 
-echo "[install] Installing systemd units as symlinks..."
 mkdir -p "$SERVICE_DIR"
 
+# Refuse to clobber another installation's timer/service units.
+#
+# Both are namespaced by SNAPSHOT_TIMER_NAME (snapshots/config.sh), but two
+# checkouts that forgot to give the second a distinct name would both
+# resolve to the same $SERVICE_DIR/$TIMER_NAME and $SERVICE_DIR/$SERVICE_NAME
+# -- a plain install would silently replace the first checkout's units, and
+# because ExecStart embeds that checkout's own REPO_ROOT, the daily snapshot
+# would end up running the wrong scripts under the second checkout's name.
+# Fail loudly instead, the same check 50-service-install.sh already applies
+# to the Quadlet: if the symlink is already here and does NOT point at this
+# checkout's own file, it belongs to another installation.
+check_not_foreign() {
+    TARGET="$1"; SOURCE="$2"
+    if [ -L "$TARGET" ]; then
+        EXISTING_TARGET="$(readlink -f "$TARGET" 2>/dev/null || true)"
+        SOURCE_REAL="$(readlink -f "$SOURCE" 2>/dev/null || echo "$SOURCE")"
+        if [ "$EXISTING_TARGET" != "$SOURCE_REAL" ]; then
+            echo "ERROR: '$TARGET' already exists and points at"
+            echo "       '${EXISTING_TARGET:-<unresolvable>}', not this checkout's"
+            echo "       '$SOURCE_REAL'."
+            echo "       SNAPSHOT_TIMER_NAME='${SNAPSHOT_TIMER_NAME}' is already in use"
+            echo "       by another installation of this project on this host. Give"
+            echo "       this one a distinct SNAPSHOT_TIMER_NAME in config.sh, or run"
+            echo "       ./snapshots/72-timer-uninstall.sh from the other checkout"
+            echo "       first."
+            exit 1
+        fi
+    elif [ -e "$TARGET" ]; then
+        echo "ERROR: '$TARGET' exists but is not a symlink this script wrote."
+        echo "       Something placed it by hand. Move it aside and re-run."
+        exit 1
+    fi
+}
+
+check_not_foreign "$SERVICE_DIR/$TIMER_NAME" "$TIMER_UNIT"
+check_not_foreign "$SERVICE_DIR/$SERVICE_NAME" "$RENDERED_SERVICE"
+
+echo "[install] Installing systemd units as symlinks..."
 for TARGET in "$SERVICE_DIR/$TIMER_NAME" "$SERVICE_DIR/$SERVICE_NAME"; do
     if [ -e "$TARGET" ]; then
         echo "[install] Removing old file $TARGET"

--- a/tests/check-repos-scripts.sh
+++ b/tests/check-repos-scripts.sh
@@ -708,6 +708,38 @@ run "$T/scripts/21-check-timer-install.sh"
   && [ -L "$UNIT_DIR/$TIMER_NAME" ] && [ -L "$UNIT_DIR/$SERVICE_NAME" ]; }
 assert "21.5 re-running is idempotent -- old symlinks replaced, not duplicated" $?
 
+# A symlink pointing anywhere other than this checkout's own unit is another
+# installation's, sharing this UNIT_DIR because CHECK_TIMER_NAME was never
+# made distinct (scripts/config.sh). Mirrors 50-service-install.sh's own
+# not-this-checkout's-Quadlet check.
+new_check_tree; reset_env
+echo decoy > "$WORK/foreign.timer"
+ln -s "$WORK/foreign.timer" "$UNIT_DIR/$TIMER_NAME"
+run "$T/scripts/21-check-timer-install.sh"
+{ [ "$RC" -ne 0 ] && [[ "$OUT" == *"already in use"* ]] \
+  && [ "$(readlink "$UNIT_DIR/$TIMER_NAME")" = "$WORK/foreign.timer" ] \
+  && [ ! -e "$UNIT_DIR/$SERVICE_NAME" ]; }
+assert "21.6 a timer symlink belonging to another installation is refused, untouched" $?
+
+new_check_tree; reset_env
+echo decoy > "$WORK/foreign.service"
+ln -s "$WORK/foreign.service" "$UNIT_DIR/$SERVICE_NAME"
+run "$T/scripts/21-check-timer-install.sh"
+{ [ "$RC" -ne 0 ] && [[ "$OUT" == *"already in use"* ]] \
+  && [ "$(readlink "$UNIT_DIR/$SERVICE_NAME")" = "$WORK/foreign.service" ] \
+  && [ ! -e "$UNIT_DIR/$TIMER_NAME" ]; }
+assert "21.7 a service symlink belonging to another installation is refused, untouched" $?
+
+# A plain file (not a symlink this or any install ever wrote) is refused too
+# -- something placed it by hand, and silently replacing it would destroy
+# whatever that was.
+new_check_tree; reset_env
+echo "not a symlink" > "$UNIT_DIR/$TIMER_NAME"
+run "$T/scripts/21-check-timer-install.sh"
+{ [ "$RC" -ne 0 ] && [[ "$OUT" == *"not a symlink this script wrote"* ]] \
+  && [ ! -L "$UNIT_DIR/$TIMER_NAME" ] && [ -f "$UNIT_DIR/$TIMER_NAME" ]; }
+assert "21.8 a hand-placed regular file at the timer path is refused, untouched" $?
+
 # ============================================================================
 # 22. 22-check-timer-uninstall.sh
 # ============================================================================

--- a/tests/snapshot-scripts.sh
+++ b/tests/snapshot-scripts.sh
@@ -733,6 +733,38 @@ run "$T/snapshots/71-timer-install.sh"
   && [ -L "$UNIT_DIR/$TIMER_NAME" ] && [ -L "$UNIT_DIR/$SERVICE_NAME" ]; }
 assert "71.5 re-running is idempotent -- old symlinks replaced, not duplicated" $?
 
+# A symlink pointing anywhere other than this checkout's own unit is another
+# installation's, sharing this UNIT_DIR because SNAPSHOT_TIMER_NAME was never
+# made distinct (snapshots/config.sh). Mirrors 50-service-install.sh's own
+# not-this-checkout's-Quadlet check.
+new_snap_tree; reset_env
+echo decoy > "$WORK/foreign.timer"
+ln -s "$WORK/foreign.timer" "$UNIT_DIR/$TIMER_NAME"
+run "$T/snapshots/71-timer-install.sh"
+{ [ "$RC" -ne 0 ] && [[ "$OUT" == *"already in use"* ]] \
+  && [ "$(readlink "$UNIT_DIR/$TIMER_NAME")" = "$WORK/foreign.timer" ] \
+  && [ ! -e "$UNIT_DIR/$SERVICE_NAME" ]; }
+assert "71.6 a timer symlink belonging to another installation is refused, untouched" $?
+
+new_snap_tree; reset_env
+echo decoy > "$WORK/foreign.service"
+ln -s "$WORK/foreign.service" "$UNIT_DIR/$SERVICE_NAME"
+run "$T/snapshots/71-timer-install.sh"
+{ [ "$RC" -ne 0 ] && [[ "$OUT" == *"already in use"* ]] \
+  && [ "$(readlink "$UNIT_DIR/$SERVICE_NAME")" = "$WORK/foreign.service" ] \
+  && [ ! -e "$UNIT_DIR/$TIMER_NAME" ]; }
+assert "71.7 a service symlink belonging to another installation is refused, untouched" $?
+
+# A plain file (not a symlink this or any install ever wrote) is refused too
+# -- something placed it by hand, and silently replacing it would destroy
+# whatever that was.
+new_snap_tree; reset_env
+echo "not a symlink" > "$UNIT_DIR/$TIMER_NAME"
+run "$T/snapshots/71-timer-install.sh"
+{ [ "$RC" -ne 0 ] && [[ "$OUT" == *"not a symlink this script wrote"* ]] \
+  && [ ! -L "$UNIT_DIR/$TIMER_NAME" ] && [ -f "$UNIT_DIR/$TIMER_NAME" ]; }
+assert "71.8 a hand-placed regular file at the timer path is refused, untouched" $?
+
 # ============================================================================
 # 72. 72-timer-uninstall.sh
 # ============================================================================


### PR DESCRIPTION
## Summary

Addresses an external repo assessment finding (LOW, robustness not a security break): `scripts/21-check-timer-install.sh` removes existing same-named timer/service files unconditionally and recreates its symlinks, whereas `scripts/50-service-install.sh` is more careful and explicitly checks whether an existing Quadlet file belongs to this checkout before overwriting it. The suggestion was to apply the same pattern to the timer installer.

While verifying, I found the same gap also applies to `snapshots/71-timer-install.sh` (identical unconditional-`rm -f` loop) — not mentioned in the original finding, but the same script family and the same fix.

Not remotely exploitable — this is about two checkouts of this project under the *same* operator account accidentally overwriting each other's timer if they forgot to give the second a distinct `CHECK_TIMER_NAME`/`SNAPSHOT_TIMER_NAME`.

## Changes

- `scripts/21-check-timer-install.sh` and `snapshots/71-timer-install.sh`: before removing/relinking each unit, refuse if it already exists as a symlink pointing somewhere other than this checkout's own file (another installation), or if it exists and isn't a symlink at all (placed by hand). Same check `50-service-install.sh:121-149` already applies to the Quadlet, ported to the two-file (timer + service) case.
- The original `[install] Removing old file` per-target log line is preserved, now gated behind the new check instead of running unconditionally — a same-checkout re-run stays exactly as idempotent as before.
- New tests: `tests/check-repos-scripts.sh` 21.6-21.8 and `tests/snapshot-scripts.sh` 71.6-71.8 — a foreign timer symlink, a foreign service symlink, and a hand-placed regular file are each refused and left untouched.

## Verification
- `tests/check-repos-scripts.sh`: 58 -> 61/61 (3 new cases, no regressions — existing idempotent-reinstall case 21.5 still passes).
- `tests/snapshot-scripts.sh`: 56 -> 59/59 (3 new cases, 71.5 still passes).
- `shellcheck --severity=warning`: clean on all four changed files.

## Test plan
- [x] Both test suites pass locally, including the new foreign-unit and hand-placed-file cases
- [x] The existing idempotent re-run case is unaffected
- [ ] CI `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE