### PR TITLE
feat: SBOM generation and a CRITICAL-only vulnerability gate (M-02)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ jobs:
       packages: write
       id-token: write        # required to mint the Sigstore signing identity
       attestations: write    # required to publish the build attestation
+      security-events: write # required to upload the Trivy SARIF report
 
     steps:
       - name: Checkout
@@ -68,6 +69,46 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          sbom: true
+
+      # Scans the amd64 image (Trivy's default platform on an amd64 runner,
+      # unmodified here); the two architectures share a Dockerfile and an apt
+      # install pinned to the same package versions (Dockerfile), so they do
+      # not carry different vulnerabilities.
+      #
+      # Two runs against the same digest, not one, because they answer
+      # different questions and fail the build in different ways:
+      #   - This one is the full picture (every severity, fixed or not),
+      #     uploaded to the Security tab so it is visible without blocking
+      #     anything. It never fails the job (no exit-code set).
+      #   - The gate below is deliberately narrow: CRITICAL only, and
+      #     --ignore-unfixed so a CVE with no available fix cannot block a
+      #     release indefinitely over something no commit here can act on
+      #     (the same reasoning tests/base-image-freshness.sh's header gives
+      #     for not running on pull requests -- a red build with no
+      #     available fix teaches people to ignore red builds).
+      - name: Vulnerability scan (report, all severities)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/raykhoefemann/hardened-borg-server@${{ steps.push.outputs.digest }}
+          scanners: vuln
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload vulnerability report to the Security tab
+        uses: github/codeql-action/upload-sarif@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Vulnerability gate (fixable CRITICAL only)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/raykhoefemann/hardened-borg-server@${{ steps.push.outputs.digest }}
+          scanners: vuln
+          format: table
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
 
       - name: Attest build provenance
         # Not pushed to the OCI registry (push-to-registry defaults to false):


### PR DESCRIPTION
## Summary

Addresses M-02 from an external repo assessment ("Keine echte SBOM-/Vulnerability-Gate-Pipeline", supply-chain hardening, not a current vulnerability): `docker.yml` builds and pushes with a provenance attestation but generates no SBOM and runs no vulnerability scan.

## Changes

- `sbom: true` on the existing `docker/build-push-action` step — BuildKit's native SBOM generator, attested the same way provenance already is. No new tool.
- A full-severity Trivy scan uploaded as SARIF to the repo's Security tab — informational only, does not fail the job.
- A second, narrow Trivy run that **gates the release**: `severity=CRITICAL` + `--ignore-unfixed`, `exit-code: 1`.

## Why CRITICAL + ignore-unfixed, not "any severity"

Confirmed locally against the currently-released `ghcr.io/.../hardened-borg-server:1.1.2` image: a full scan reports 380 SARIF findings across all severities, almost entirely open-but-unfixed LOW/MEDIUM CVEs in base packages unrelated to this server's own code (`util-linux`, `zlib1g`). A Debian base image essentially always carries some of these. Gating on all of that would block every release on something no commit in this repo can act on — the same failure mode `tests/base-image-freshness.sh`'s own header already warns about: *"a red build that only ever means wait teaches people to ignore red builds"*. CRITICAL + `--ignore-unfixed` keeps the gate to things that are both severe and something a rebuild can actually fix.

With those parameters, the same 1.1.2 image scans clean (0 findings) — merging this does not retroactively fail anything.

## Verification

`docker.yml` only runs on a tag push, so this PR's own CI cannot exercise these new steps (same constraint every prior Actions-pinning change in this project has had). Verified locally instead, against the real released image, with the exact Trivy invocations used here:
- Full-severity SARIF scan: produces valid SARIF JSON (380 results).
- CRITICAL + `--ignore-unfixed` gate: passes clean (0 findings, exit 0).
- `python3 -c "import yaml; yaml.safe_load(...)"`: `docker.yml` parses.

Real end-to-end validation happens at the next tag push, the same way the SHA-pinned Actions in `v1.1.2` were only proven live by that release's own build.

## Test plan
- [x] YAML validates
- [x] Both Trivy invocations verified locally against the real 1.1.2 image with identical parameters
- [ ] Next release's `Docker Build & Publish` run exercises the new steps for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE