### PR TITLE
fix: register the Trivy SARIF upload against main, not the release tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,9 +96,18 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload vulnerability report to the Security tab
+        # ref/sha pin this to the commit the tag points at (which is what
+        # github.sha already resolves to on a tag push), not the tag ref
+        # itself. Without this, results attach to refs/tags/<tag> and the
+        # Security tab's default view -- which only shows the default
+        # branch -- never surfaces them; they exist but only via the API
+        # with ?ref=refs/tags/<tag> explicitly. v1.1.3's own upload has
+        # this problem; every release from here on does not.
         uses: github/codeql-action/upload-sarif@fddeee1a7ece751b577e409a89057319e3172939 # v4
         with:
           sarif_file: trivy-results.sarif
+          ref: refs/heads/main
+          sha: ${{ github.sha }}
 
       - name: Vulnerability gate (fixable CRITICAL only)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0


### PR DESCRIPTION
## Summary

Follow-up to M-02 (#47), found while verifying `v1.1.3`'s first real run of the new SBOM/vulnerability-gate pipeline: `github/codeql-action/upload-sarif` defaults `ref`/`sha` to `GITHUB_REF`/`GITHUB_SHA`, which on a tag push resolve to `refs/tags/<tag>` — not a branch. GitHub's Security tab only shows alerts for the default branch by default, so the upload succeeded and was processed (confirmed via the API: 380 results, 30 open alerts under `?ref=refs/tags/v1.1.3`) but never appeared in the normal Security tab view — defeating the point of "visible without hunting" that this step exists for.

## Change

Pinned `ref: refs/heads/main` and `sha: ${{ github.sha }}` on the upload-sarif step. `github.sha` already resolves to the commit a tag points at on a tag push event, and every release tag in this project is cut from a commit on `main`, so this attaches the finding to the branch that actually produced it — not a misrepresentation, just correcting where the report is filed.

No change to the vulnerability gate itself (`severity=CRITICAL` + `--ignore-unfixed`, still the actual safety mechanism) — this only affects the informational report's visibility.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"`: parses.
- `github/codeql-action/upload-sarif`'s own `action.yml` confirms `ref`/`sha` are supported inputs, used exactly as documented.
- Real verification happens at the next tag push (same constraint as every prior `docker.yml` change) — `v1.1.3`'s own upload is not retroactively fixed, this applies from the next release on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rAJ4jT6W1WPcyChBKyDXE